### PR TITLE
Fix bug when response empty content and no content-type header present

### DIFF
--- a/src/fetchJSON.js
+++ b/src/fetchJSON.js
@@ -25,7 +25,7 @@ const fetchJSON = (url: string | Request | URL, options: Object = {}) => {
 
 const getResponseBody = (response: Response): Promise<ResponseBody> => {
   const contentType = response.headers.get('content-type')
-  return contentType.indexOf('json') >= 0 ? response.text().then(tryParseJSON) : response.text()
+  return contentType && contentType.indexOf('json') >= 0 ? response.text().then(tryParseJSON) : response.text()
 }
 
 const tryParseJSON = (json: string): Object | null => {


### PR DESCRIPTION
For instance when doing a DELETE request and the server returns HTTP 204 No Content without content-type header, the code would break when checking the content type for 'json'.
This fix checks if content-type header was present or not.