### PR TITLE
fetchJSON: Don't send a `Content-Type` header without a body

### DIFF
--- a/src/fetchJSON.js
+++ b/src/fetchJSON.js
@@ -6,7 +6,9 @@ import merge from 'lodash/merge'
 type ResponseBody = Object | null | string
 
 const fetchJSON = (url: string | Request | URL, options: Object = {}) => {
-  const jsonOptions = merge(
+  // The Content-Type header describes the type of the body so should be
+  // omitted when there isn't one.
+  const fetchOptions = typeof (options.body) === 'undefined' ? options : merge(
     {
       headers: {
         'Content-Type': 'application/json'
@@ -15,7 +17,7 @@ const fetchJSON = (url: string | Request | URL, options: Object = {}) => {
     options
   )
 
-  return fetch(url, jsonOptions)
+  return fetch(url, fetchOptions)
     .then((response: Response) => {
       return getResponseBody(response).then(body => ({
         response,

--- a/test/fetchJSON.spec.js
+++ b/test/fetchJSON.spec.js
@@ -1,0 +1,64 @@
+/* eslint-env jest */
+
+beforeEach(() => {
+  const mockFetch = jest.fn()
+  Object.defineProperty(global, 'fetch', { value: mockFetch, writable: true })
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('fetchJSON', () => {
+  it('should call fetch with no additional headers without a body', (done) => {
+    import('../src').then(({ fetchJSON }) => {
+      // Mock the Response
+      const mockText = jest.fn().mockReturnValueOnce(Promise.resolve(''))
+      const mockClone = jest.fn().mockImplementation(() => {
+        return {
+          text: mockText
+        }
+      })
+      global.fetch.mockReturnValueOnce(Promise.resolve({
+        clone: mockClone,
+        headers: new Headers()
+      }))
+
+      const url = '/1'
+      const options = {}
+      fetchJSON(url, options)
+      expect(global.fetch).toBeCalledWith(url, options)
+      done()
+    })
+  })
+
+  it('should call fetch with a default Content-Type header with a body', (done) => {
+    import('../src').then(({ fetchJSON }) => {
+      // Mock the Response
+      const mockText = jest.fn().mockReturnValueOnce(Promise.resolve(''))
+      const mockClone = jest.fn().mockImplementation(() => {
+        return {
+          text: mockText
+        }
+      })
+      global.fetch.mockReturnValueOnce(Promise.resolve({
+        clone: mockClone,
+        headers: new Headers()
+      }))
+
+      const url = '/2'
+      const options = {
+        body: JSON.stringify({}),
+        method: 'POST'
+      }
+      fetchJSON(url, options)
+      expect(global.fetch).toBeCalledWith(url, {
+        ...options,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      })
+      done()
+    })
+  })
+})


### PR DESCRIPTION
The Content-Type request header describes the type of the body so when there is no body (e.g. a GET request) the Content-Type header is inappropriate and leads to CORS issues since `Content-Type: application/json` prevents a request from being "simple": https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests